### PR TITLE
🐛 fix: Element div is not closed

### DIFF
--- a/02.01.fading/index.html
+++ b/02.01.fading/index.html
@@ -15,5 +15,6 @@
     <div class="green-box">Green</div>
     <div class="blue-box">Blue</div>
     <div class="clear"></div>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
Simple bug fix, element div is not closed in HTML for 02.01.fading. Thanks for the course!